### PR TITLE
Specify the version and determine the OS and architecture

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,14 +1,53 @@
 const std = @import("std");
 
-const DOWNLOAD_URI: std.Uri = .{
-    .scheme = "https",
-    .host = .{ .raw = "github.com" },
-    .path = .{ .raw = "/tailwindlabs/tailwindcss/releases/download/v4.1.11/tailwindcss-macos-x64" },
-};
+const TAILWIND_VERSION = "v4.1.11";
+const GITHUB_BASE_URL = "https://github.com/tailwindlabs/tailwindcss/releases/download/";
+
+fn getPlatformExecutableName() []const u8 {
+    const target = @import("builtin").target;
+
+    const os_name = switch (target.os.tag) {
+        .linux => "linux",
+        .macos => "macos",
+        .windows => "windows",
+        else => @panic("Unsupported operating system"),
+    };
+
+    const arch_name = switch (target.cpu.arch) {
+        .x86_64 => "x64",
+        .aarch64 => "arm64",
+        else => @panic("Unsupported architecture"),
+    };
+
+    const extension = switch (target.os.tag) {
+        .windows => ".exe",
+        else => "",
+    };
+
+    // For Linux, we'll use the musl variants for better compatibility
+    const musl_suffix = switch (target.os.tag) {
+        .linux => "-musl",
+        else => "",
+    };
+
+    return std.fmt.comptimePrint("tailwindcss-{s}-{s}{s}{s}", .{ os_name, arch_name, musl_suffix, extension });
+}
+
+fn buildDownloadUri(allocator: std.mem.Allocator) !std.Uri {
+    const executable_name = getPlatformExecutableName();
+    const path = try std.fmt.allocPrint(allocator, "/tailwindlabs/tailwindcss/releases/download/{s}/{s}", .{ TAILWIND_VERSION, executable_name });
+
+    return std.Uri{
+        .scheme = "https",
+        .host = .{ .raw = "github.com" },
+        .path = .{ .raw = path },
+    };
+}
 
 pub fn main() !void {
     var gpa: std.heap.GeneralPurposeAllocator(.{}) = .init;
     const allocator = gpa.allocator();
+    defer _ = gpa.deinit();
 
     var args = try std.process.argsWithAllocator(allocator);
     defer args.deinit();
@@ -23,11 +62,17 @@ pub fn main() !void {
     var output_file_writer = output_file.writer(&output_file_writer_buffer);
     const writer = &output_file_writer.interface;
 
+    // Build the download URI dynamically based on target platform
+    const download_uri = try buildDownloadUri(allocator);
+    defer allocator.free(download_uri.path.raw);
+
+    std.debug.print("Downloading Tailwind CSS executable for platform: {s}...\n", .{getPlatformExecutableName()});
+
     var http_client: std.http.Client = .{ .allocator = allocator };
     try http_client.initDefaultProxies(allocator);
     defer http_client.deinit();
 
-    var request = try http_client.request(.GET, DOWNLOAD_URI, .{});
+    var request = try http_client.request(.GET, download_uri, .{});
     defer request.deinit();
 
     try request.sendBodiless();


### PR DESCRIPTION
I moved this change into a branch. I'll close the other PR after creating this new one. It simply makes the version explicit via `TAILWIND_VERSION` and downloads the appropriate binary for the current architecture instead of defaulting to x64.

This is needed to avoid running under Rosetta on ARM (Apple Silicon) Macs, but will also be useful for Linux and Windows users.